### PR TITLE
Strip Alpha from PNGs

### DIFF
--- a/runner/linux/run_fifo_test.sh
+++ b/runner/linux/run_fifo_test.sh
@@ -110,7 +110,7 @@ while [ "$#" -ne 0 ]; do
             # Assume SW renderer style of .png frame dumping.
             i=0
             for f in $(ls -rt $DUMPDIR/*.png); do
-                mv -v $f `printf $OUT/frame-%03d.png $i`
+                convert -alpha deactivate $f `printf $OUT/frame-%03d.png $i`
                 i=$((i + 1))
             done
         fi


### PR DESCRIPTION
VideoSW dumps its frames with alpha, but we don't want to display them. So just strip it on dumping.