### PR TITLE
Enable panic handlers for linux fifoci's

### DIFF
--- a/runner/linux/Config-ogl/Dolphin.ini
+++ b/runner/linux/Config-ogl/Dolphin.ini
@@ -2,7 +2,7 @@
 Fullscreen = True
 [Interface]
 ConfirmStop = False
-UsePanicHandlers = False
+UsePanicHandlers = True
 [Core]
 CPUThread = False
 [FifoPlayer]

--- a/runner/linux/Config-sw/Dolphin.ini
+++ b/runner/linux/Config-sw/Dolphin.ini
@@ -2,7 +2,7 @@
 Fullscreen = True
 [Interface]
 ConfirmStop = False
-UsePanicHandlers = False
+UsePanicHandlers = True
 [Core]
 CPUThread = False
 GFXBackend = Software Renderer


### PR DESCRIPTION
Leave them disabled for windows, as Windows doesn't have a proper no-gui build and will pop-up a dialog.