### PR TITLE
runner: Use subprocess.call instead of os.system.

### DIFF
--- a/runner/linux/Config-ogl/Dolphin.ini
+++ b/runner/linux/Config-ogl/Dolphin.ini
@@ -11,3 +11,6 @@ LoopReplay = False
 DumpFrames = True
 [DSP]
 Backend = No audio output
+[Analytics]
+Enabled = False
+PermissionAsked = True

--- a/runner/linux/Config-sw/Dolphin.ini
+++ b/runner/linux/Config-sw/Dolphin.ini
@@ -12,3 +12,6 @@ LoopReplay = False
 DumpFrames = True
 [DSP]
 Backend = No audio output
+[Analytics]
+Enabled = False
+PermissionAsked = True

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -142,7 +142,7 @@ def spawn_tests(args, targets):
                         % (base_path, backend, driver, args.dolphin,
                            target_descr))
     elif system == 'win':
-        ret = os.system('powershell %s/windows/run_fifo_test.ps1 %s %s %s %s'
+        ret = subprocess.call('powershell %s/windows/run_fifo_test.ps1 %s %s %s %s'
                         % (base_path, backend, driver, args.dolphin,
                            target_descr))
     else:

--- a/runner/windows/Config-dx-nv/Dolphin.ini
+++ b/runner/windows/Config-dx-nv/Dolphin.ini
@@ -15,3 +15,6 @@ LoopReplay = False
 [Movie]
 DumpFrames = True
 DumpFramesSilent = True
+[Analytics]
+Enabled = False
+PermissionAsked = True


### PR DESCRIPTION
Windows can't handle command lines larger than 8191 characters. At first I wanted to reduce the command-line length, but it looks like there was a much easier fix to handle huge command lines.

subprocess.call is intended to replace os.system and *does* allow for larger command-lines. I tested this locally on my own Windows setup and it works fine.

I also added some config changes so the analytics are off by default or else the FIFO log won't run because it's waiting for user input.