### PR TITLE
Turn on "Immediate Mode" which avoids VI calls and processes the XFB right away

### DIFF
--- a/runner/linux/Config-ogl/GFX.ini
+++ b/runner/linux/Config-ogl/GFX.ini
@@ -3,3 +3,4 @@ UseFFV1 = True
 [Hacks]
 EFBScaledCopy = False
 EFBEmulateFormatChanges = True
+ImmediateXFBEnable = True

--- a/runner/linux/Config-sw/GFX.ini
+++ b/runner/linux/Config-sw/GFX.ini
@@ -2,3 +2,5 @@
 UseFFV1 = True
 [Rendering]
 BypassXFB = True
+[Hacks]
+ImmediateXFBEnable = True

--- a/runner/windows/Config-dx-nv/GFX.ini
+++ b/runner/windows/Config-dx-nv/GFX.ini
@@ -3,3 +3,4 @@ UseFFV1 = True
 [Hacks]
 EFBScaledCopy = False
 EFBEmulateFormatChanges = True
+ImmediateXFBEnable = True


### PR DESCRIPTION
We need to turn on "Immediate Mode" for when HybridXFB gets merged.  This will allow fifoci to act the same way it does now when "No XFB" is enabled (which is the default on master).  Fifo ci currently behaves incorrectly when XFB is enabled, so that is why this is needed.