### PR TITLE
Fix capitalization in audio backend

### DIFF
--- a/runner/linux/Config-ogl/Dolphin.ini
+++ b/runner/linux/Config-ogl/Dolphin.ini
@@ -10,7 +10,7 @@ LoopReplay = False
 [Movie]
 DumpFrames = True
 [DSP]
-Backend = No audio output
+Backend = No Audio Output
 [Analytics]
 Enabled = False
 PermissionAsked = True

--- a/runner/linux/Config-sw/Dolphin.ini
+++ b/runner/linux/Config-sw/Dolphin.ini
@@ -11,7 +11,7 @@ LoopReplay = False
 [Movie]
 DumpFrames = True
 [DSP]
-Backend = No audio output
+Backend = No Audio Output
 [Analytics]
 Enabled = False
 PermissionAsked = True


### PR DESCRIPTION
This prevents the runners from attempting to create a ALSA backend in the first place, which was the cause of the recent regression.