### PR TITLE
run_fifo_test: Use *.avi instead of framedump0.avi

### DIFF
--- a/runner/linux/run_fifo_test.sh
+++ b/runner/linux/run_fifo_test.sh
@@ -64,7 +64,7 @@ while [ "$#" -ne 0 ]; do
     else
         echo "FIFO playback done, extracting frames to $OUT"
 
-        AVIFILE=$DUMPDIR/framedump0.avi
+        AVIFILE=$DUMPDIR/*.avi
         if [ -f "$AVIFILE" ]; then
             ffmpeg -i $AVIFILE -f image2 $OUT/frame-%3d.png \
                 &> >(show_logs ffmpeg)


### PR DESCRIPTION
See #26.  dolphin-emu/dolphin#9182 changed the default filename to be timestamped, instead of incremental; as such framedump0.avi is no longer created.

Only one file should be created, so the wildcard shouldn't cause issues.