### PR TITLE
Enable FRAMEDUMP log type and fix expansion of *.avi

### DIFF
--- a/runner/linux/Config-ogl/Logger.ini
+++ b/runner/linux/Config-ogl/Logger.ini
@@ -49,3 +49,4 @@ WII_IPC_HID = True
 WII_IPC_WC24 = True
 WII_IPC_SSL = True
 Host GPU = False
+FRAMEDUMP = True

--- a/runner/linux/Config-sw/Logger.ini
+++ b/runner/linux/Config-sw/Logger.ini
@@ -49,3 +49,4 @@ WII_IPC_HID = True
 WII_IPC_WC24 = True
 WII_IPC_SSL = True
 Host GPU = False
+FRAMEDUMP = True

--- a/runner/linux/run_fifo_test.sh
+++ b/runner/linux/run_fifo_test.sh
@@ -64,9 +64,9 @@ while [ "$#" -ne 0 ]; do
     else
         echo "FIFO playback done, extracting frames to $OUT"
 
-        AVIFILE=$DUMPDIR/*.avi
+        AVIFILE=$(echo $DUMPDIR/*.avi)
         if [ -f "$AVIFILE" ]; then
-            ffmpeg -i $AVIFILE -f image2 $OUT/frame-%3d.png \
+            ffmpeg -i "$AVIFILE" -f image2 $OUT/frame-%3d.png \
                 &> >(show_logs ffmpeg)
         else
             # Assume SW renderer style of .png frame dumping.


### PR DESCRIPTION
The framedump log type change is due to dolphin-emu/dolphin@bca82bb942ce55f3f83aeca26b5d7a80d0e1a265, which caused the "Opening file [path] for dumping" message (among others) to disappear.

The bigger issue was that #27 didn't fix the file not being found, because `*.avi` wasn't expanded due to the quotes in `[ -f "$AVIFILE" ]`.  It's now expanded ahead of time.  I've also added quotes around the use for ffmpeg, since if we care about spaces in the filename, it probably should be handled for both of them.  There will still be issues if multiple files match, since the combined filename won't exist, but that shouldn't be an issue in practice.  (Again, see #26.)