### PR TITLE
Revert "Strip Alpha from PNGs"

### DIFF
--- a/runner/linux/run_fifo_test.sh
+++ b/runner/linux/run_fifo_test.sh
@@ -72,7 +72,7 @@ while [ "$#" -ne 0 ]; do
             # Assume SW renderer style of .png frame dumping.
             i=0
             for f in $(ls -rt $DUMPDIR/*.png); do
-                convert -alpha deactivate $f `printf $OUT/frame-%03d.png $i`
+                mv -v $f `printf $OUT/frame-%03d.png $i`
                 i=$((i + 1))
             done
         fi


### PR DESCRIPTION
This reverts commit 2a9794dd84575e637ae9f55b0c0ad4b355b24107.

The commit that made Dolphin stop outputting alpha was merged 5 years ago (https://github.com/dolphin-emu/dolphin/pull/3157), so there's no longer much reason to keep this around.

The main reason why I want to revert this is because the code doesn't actually work right now due to imagemagick not being installed. The code path is currently not being used, but I would like to start using it again (see https://github.com/dolphin-emu/dolphin/pull/9275).