### PR TITLE
Dump to PNG files instead of AVI files

### DIFF
--- a/runner/linux/Config-ogl/GFX.ini
+++ b/runner/linux/Config-ogl/GFX.ini
@@ -1,4 +1,5 @@
 [Settings]
+DumpFramesAsImages = True
 UseFFV1 = True
 [Hacks]
 EFBScaledCopy = False

--- a/runner/linux/Config-sw/GFX.ini
+++ b/runner/linux/Config-sw/GFX.ini
@@ -1,4 +1,5 @@
 [Settings]
+DumpFramesAsImages = True
 UseFFV1 = True
 [Rendering]
 BypassXFB = True

--- a/runner/linux/run_fifo_test.sh
+++ b/runner/linux/run_fifo_test.sh
@@ -69,7 +69,7 @@ while [ "$#" -ne 0 ]; do
             ffmpeg -i "$AVIFILE" -f image2 $OUT/frame-%3d.png \
                 &> >(show_logs ffmpeg)
         else
-            # Assume SW renderer style of .png frame dumping.
+            # Assume PNG frame dumping.
             i=1
             for f in $(ls -rt $DUMPDIR/*.png); do
                 mv -v $f `printf $OUT/frame-%03d.png $i`

--- a/runner/windows/Config-dx-nv/GFX.ini
+++ b/runner/windows/Config-dx-nv/GFX.ini
@@ -1,4 +1,5 @@
 [Settings]
+DumpFramesAsImages = True
 UseFFV1 = True
 [Hacks]
 EFBScaledCopy = False


### PR DESCRIPTION
When Dolphin presents a frame, it is associated with a point in emulated time at which it is considered to have been presented. This timing information is used by Dolphin's AVI dumping code and saved to the AVI file. This leads to a potential problem for FifoCI: If the duration of a frame is longer than one field (as determined by the VI registers, and subject to rounding), it will be treated as two or more frames when FifoCI uses ffmpeg to turn the AVI file into PNG frames.

Since we are only interested in the frames themselves and not the associated timing information, I believe it would be better for us to use Dolphin's ability to dump frames to PNG files, as that code path ignores the timing information. PNG is what we want in the end anyway, so this lets us skip extra conversion steps involving ffmpeg.

In case you would like to confirm that this doesn't break anything, I currently have a commit appended to https://github.com/dolphin-emu/dolphin/pull/9275 which makes FifoCI use the PNG code path, and FifoCI is not reporting any diffs for that PR.