### PR TITLE
runner: Abort on panic alert

### DIFF
--- a/runner/linux/Config-ogl/Dolphin.ini
+++ b/runner/linux/Config-ogl/Dolphin.ini
@@ -3,6 +3,7 @@ Fullscreen = True
 [Interface]
 ConfirmStop = False
 UsePanicHandlers = True
+AbortOnPanicAlert = True
 [Core]
 CPUThread = False
 [FifoPlayer]

--- a/runner/linux/Config-sw/Dolphin.ini
+++ b/runner/linux/Config-sw/Dolphin.ini
@@ -3,6 +3,7 @@ Fullscreen = True
 [Interface]
 ConfirmStop = False
 UsePanicHandlers = True
+AbortOnPanicAlert = True
 [Core]
 CPUThread = False
 GFXBackend = Software Renderer

--- a/runner/linux/Config-uberogl/Dolphin.ini
+++ b/runner/linux/Config-uberogl/Dolphin.ini
@@ -3,6 +3,7 @@ Fullscreen = True
 [Interface]
 ConfirmStop = False
 UsePanicHandlers = True
+AbortOnPanicAlert = True
 [Core]
 CPUThread = False
 [FifoPlayer]

--- a/runner/windows/Config-dx-nv/Dolphin.ini
+++ b/runner/windows/Config-dx-nv/Dolphin.ini
@@ -7,6 +7,7 @@ RenderToMain = False
 [Interface]
 ConfirmStop = False
 UsePanicHandlers = False
+AbortOnPanicAlert = True
 [Core]
 CPUThread = False
 GFXBackend = D3D


### PR DESCRIPTION
Prompted by https://dolphin.ci/#/builders/24/builds/985

A 1-character typo in a recent PR caused FifoCI builds to break
horribly and spew millions of panic alerts until buildbot crashed.

This PR enables a new config option that allows Dolphin to abort early
on when a panic alert occurs instead of continuing forever.

~~Requires PR dolphin-emu/dolphin#10066~~ merged now