### PR TITLE
runner: Enable master log type

### DIFF
--- a/runner/linux/Config-ogl/Logger.ini
+++ b/runner/linux/Config-ogl/Logger.ini
@@ -22,6 +22,7 @@ PowerPC = True
 GP = True
 HLE = True
 MI = True
+MASTER = True
 MemCard Manager = True
 OSREPORT = True
 PAD = True

--- a/runner/linux/Config-sw/Logger.ini
+++ b/runner/linux/Config-sw/Logger.ini
@@ -22,6 +22,7 @@ PowerPC = True
 GP = True
 HLE = True
 MI = True
+MASTER = True
 MemCard Manager = True
 OSREPORT = True
 PAD = True

--- a/runner/linux/Config-uberogl/Logger.ini
+++ b/runner/linux/Config-uberogl/Logger.ini
@@ -22,6 +22,7 @@ PowerPC = True
 GP = True
 HLE = True
 MI = True
+MASTER = True
 MemCard Manager = True
 OSREPORT = True
 PAD = True


### PR DESCRIPTION
Panic alerts (including failed assertions) go into this type, so it's something that should be enabled.  Untested (but I don't see any way this could go wrong).