### PR TITLE
runner: Enable early memory updates and manual texture sampling on OSX

### DIFF
--- a/runner/macos/Config-mvk/Dolphin.ini
+++ b/runner/macos/Config-mvk/Dolphin.ini
@@ -9,6 +9,7 @@ CPUThread = False
 GFXBackend = Vulkan
 [FifoPlayer]
 LoopReplay = False
+EarlyMemoryUpdates = True
 [Movie]
 DumpFrames = True
 [DSP]

--- a/runner/macos/Config-mvk/GFX.ini
+++ b/runner/macos/Config-mvk/GFX.ini
@@ -5,3 +5,4 @@ UseFFV1 = True
 EFBScaledCopy = False
 EFBEmulateFormatChanges = True
 ImmediateXFBEnable = True
+FastTextureSampling = False


### PR DESCRIPTION
These should eliminate the random graphical differences; at least, it will definitely eliminate the differences caused by textures loading at different times (since early memory updates solves that at the cost of inaccurate handling of other aspects of memory updates).  Hopefully, manual texture sampling will also solve the random variability with EFB copies, but I'm not 100% sure of that.

The early memory updates aspect depends on dolphin-emu/dolphin#10355.  **This FifoCI PR should be merged and deployed _before_ the dolphin PR is merged**, so that the large number of rendering differences caused by manual texture sampling and early memory updates are attributed to that PR instead of whatever random PR comes after it.