### PR TITLE
Switch log level to Info instead of Warning

### DIFF
--- a/runner/linux/Config-ogl/Logger.ini
+++ b/runner/linux/Config-ogl/Logger.ini
@@ -1,5 +1,5 @@
 [Options]
-Verbosity = 3
+Verbosity = 4
 WriteToConsole = True
 [Logs]
 ActionReplay = True

--- a/runner/linux/Config-sw/Logger.ini
+++ b/runner/linux/Config-sw/Logger.ini
@@ -1,5 +1,5 @@
 [Options]
-Verbosity = 3
+Verbosity = 4
 WriteToConsole = True
 [Logs]
 ActionReplay = True

--- a/runner/linux/Config-uberogl/Logger.ini
+++ b/runner/linux/Config-uberogl/Logger.ini
@@ -1,5 +1,5 @@
 [Options]
-Verbosity = 3
+Verbosity = 4
 WriteToConsole = True
 [Logs]
 ActionReplay = True

--- a/runner/macos/Config-mvk/Logger.ini
+++ b/runner/macos/Config-mvk/Logger.ini
@@ -1,5 +1,5 @@
 [Options]
-Verbosity = 3
+Verbosity = 4
 WriteToConsole = True
 [Logs]
 ActionReplay = True


### PR DESCRIPTION
Intended to be combined with dolphin-emu/dolphin#10474, but there may also be information in the log that is missed due to the level being set to warning.