### PR TITLE
Config-uberogl: Enable DumpFramesAsImages

### DIFF
--- a/runner/linux/Config-uberogl/GFX.ini
+++ b/runner/linux/Config-uberogl/GFX.ini
@@ -1,4 +1,5 @@
 [Settings]
+DumpFramesAsImages = True
 UseFFV1 = True
 ShaderCompilationMode = 1
 [Hacks]


### PR DESCRIPTION
This fixes the duplicated 3rd frame on fifoci-uberogl-lin-radeon, as it was generating an AVI file from which the frames were extracted, instead of dumping directly as PNGs.

Tested at dolphin-emu/dolphin#10505.  I recommend merging this and then immediately afterwards merging dolphin-emu/dolphin#10504 so that the resulting fifoci differences are attributed to that PR (instead of whatever random unrelated PR is merged next).