### PR TITLE
runner:macos: Disable early memory updates, manual texture sampling, and mipmapping

### DIFF
--- a/runner/macos/Config-mvk/Dolphin.ini
+++ b/runner/macos/Config-mvk/Dolphin.ini
@@ -9,7 +9,7 @@ CPUThread = False
 GFXBackend = Vulkan
 [FifoPlayer]
 LoopReplay = False
-EarlyMemoryUpdates = True
+EarlyMemoryUpdates = False
 [Movie]
 DumpFrames = True
 [DSP]

--- a/runner/macos/Config-mvk/GFX.ini
+++ b/runner/macos/Config-mvk/GFX.ini
@@ -5,4 +5,5 @@ UseFFV1 = True
 EFBScaledCopy = False
 EFBEmulateFormatChanges = True
 ImmediateXFBEnable = True
-FastTextureSampling = False
+FastTextureSampling = True
+NoMipmapping = True

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -62,9 +62,14 @@ def recent_enough():
     b7916f965530b0369bf08ed6bc9ec3ef20f7cd2f fixes a WX assert error that
     causes freezes on Windows FifoCI (and is a close descendent of another
     commits that adds DumpFramesSilent to remove more interactivity).
+
+    f28e5607fec604f998994e5d65931707eafec841 adds the option to disable
+    mipmapping, which is required by the macOS config.
     """
-    return os.system('git merge-base --is-ancestor '
-                     'b7916f965530b0369bf08ed6bc9ec3ef20f7cd2f HEAD') == 0
+    required = 'b7916f965530b0369bf08ed6bc9ec3ef20f7cd2f'
+    if sys.platform == 'darwin':
+        required = 'f28e5607fec604f998994e5d65931707eafec841'
+    return os.system('git merge-base --is-ancestor ' + required + ' HEAD') == 0
 
 
 def find_parents(rev_hash):


### PR DESCRIPTION
- Early memory updates should no longer be needed as of https://github.com/dolphin-emu/dolphin/pull/11246
- Disabling mipmapping works around an [issue in M1-non-pros](https://github.com/tellowkrinkle/MetalBugReproduction/releases/tag/BrokenMipmapRender) where the edges of triangles pick up wrong mip levels every now and then (nondeterministically)
- Manual texture sampling was enabled in an attempt to work around the mipmapping issue, but didn't end up helping.  I'm guessing issue is actually in the derivative calculation, rather than the sampling operation itself.