### PR TITLE
runner:macos: Enable master log type

### DIFF
--- a/runner/macos/Config-mvk/Logger.ini
+++ b/runner/macos/Config-mvk/Logger.ini
@@ -22,6 +22,7 @@ PowerPC = True
 GP = True
 HLE = True
 MI = True
+MASTER = True
 MemCard Manager = True
 OSREPORT = True
 PAD = True


### PR DESCRIPTION
See #42. Unfortunately this doesn't seem to fully explain the missing logging I'm seeing on dolphin-emu/dolphin#11123, but it still should be enabled for panic alerts.