### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FifoCI - Dolphin's continuous integration for GPU emulation
 
-See https://fifoci.dolphin-emu.org/about/
+See https://fifo.ci/about/
 
 ## Technical information
 


### PR DESCRIPTION
The README.MD was using the old URL for the homepage, which was redirecting to the homepage instead of the about page.